### PR TITLE
Fix link to Contributor Guidelines in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To setup an open-TFUS system, you'll need to follow the assembly instructions co
 This project is licensed under the GNU Affero General Public License v3.0. See [LICENSE](LICENSE) for details.
 
 # Contributing
-See [Contributor Guidelines](Contributor-Guidelines) for details.
+See [Contributor Guidelines](Contributor-Guidelines.md) for details.
 
 # Investigational Use Only
 CAUTION - Investigational device. Limited by Federal (or United States) law to investigational use. The system described here has *not* been evaluated by the FDA and is not designed for the treatment or diagnosis of any disease. It is provided AS-IS, with no warranties. User assumes all liability and responsibility for identifying and mitigating risks associated with using this software.


### PR DESCRIPTION
### Summary

The link to the Contributor Guidelines in the README leads to a 404 page. It's just missing the `.md` extension, so I've added in this PR.